### PR TITLE
Parse config before attempting envar check

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -132,6 +132,7 @@ export class App {
   }
 
   private parseConfig() {
+    if (this.config) return;
     this.config = parseConfig(this.options.config);
   }
 
@@ -165,6 +166,7 @@ export class App {
   public async deploy() {
     const release = this.generateReleaseId();
 
+    this.parseConfig(); // Need this so `this.config` is set
     for (const [podName, podConfig] of Object.entries(this.config.pods)) {
       if (podConfig.environment) {
         for (const envName of podConfig.environment) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import { parse as parseYaml } from "yaml";
 import { readFileSync } from "fs";
+import path from "path";
 import { Type, type Static } from "@sinclair/typebox";
 import { TypeCompiler } from "@sinclair/typebox/compiler";
 import { Value } from "@sinclair/typebox/value";
@@ -203,6 +204,11 @@ export function parseConfig(configPath: string) {
   }
 
   for (const [podName, podConfig] of Object.entries(config.pods)) {
+    podConfig.compose = path.resolve(
+      path.dirname(configPath),
+      podConfig.compose,
+    );
+
     const result = Bun.spawnSync([
       "docker",
       "compose",


### PR DESCRIPTION
We were failing because the config had not been checked yet.
