### PR TITLE
Grant OIDC permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: read
+  id-token: write # OIDC for Depot
+
 jobs:
   publish-docker-images:
     timeout-minutes: 10


### PR DESCRIPTION
Since we're using Depot to build a multi-arch image, grant the necessary permissions to access the builder.
