### PR TITLE
Restrict type of environment variables to only strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stack",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "license": "None",
   "private": true,
   "type": "module",

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,12 +45,7 @@ export const DeployConfigSchema = Type.Object({
         Type.Union([
           Type.Record(
             Type.String(),
-            Type.Union([
-              Type.String(),
-              Type.Number(),
-              Type.Undefined(),
-              Type.Null(),
-            ])
+            Type.Union([Type.String(), Type.Undefined()])
           ),
           Type.Array(Type.String({ pattern: "^[A-Z0-9_]+$" }), {
             uniqueItems: true,


### PR DESCRIPTION
We've had a few situations happen where using a value other than a string leads to confusing behavior. Enforce the use of string values when defining environment variables.
