### PR TITLE
Allow `null` (empty) values as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stack",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "license": "None",
   "private": true,
   "type": "module",

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,7 +45,7 @@ export const DeployConfigSchema = Type.Object({
         Type.Union([
           Type.Record(
             Type.String(),
-            Type.Union([Type.String(), Type.Undefined()])
+            Type.Union([Type.String(), Type.Undefined(), Type.Null()])
           ),
           Type.Array(Type.String({ pattern: "^[A-Z0-9_]+$" }), {
             uniqueItems: true,


### PR DESCRIPTION
We overstepped in c08debc1. Fix it.
