### PR TITLE
Add support for specifying additional instance tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stack",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "license": "None",
   "private": true,
   "type": "module",

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,6 +56,7 @@ export const DeployConfigSchema = Type.Object({
       image: Type.String({ pattern: "^ami-[a-f0-9]+$" }),
       sshUser: Type.String({ default: "ec2-user" }),
       instanceType: Type.String(),
+      instanceTags: Type.Optional(Type.Record(Type.String(), Type.String())),
       rootVolumeSize: Type.Optional(
         Type.Integer({
           minimum: 10,

--- a/src/stacks/PodStack.ts
+++ b/src/stacks/PodStack.ts
@@ -560,7 +560,7 @@ su ${podOptions.sshUser} /home/${podOptions.sshUser}/init.sh
       tagSpecifications: [
         {
           resourceType: "instance",
-          tags: sharedTags,
+          tags: { ...sharedTags, ...podOptions.instanceTags },
         },
         ...(podOptions.singleton?.networkInterfaceId
           ? [] // Avoid error "You cannot specify tags for network interfaces if there are no network interfaces being created by the request"


### PR DESCRIPTION
This currently has a niche use case for adding a `ConsulServer` tag to an EC2 instance to make discovery a little easier.
