### PR TITLE
Fix handling of HTTPS targets to also specify healthcheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stack",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "license": "None",
   "private": true,
   "type": "module",

--- a/src/stacks/PodStack.ts
+++ b/src/stacks/PodStack.ts
@@ -390,7 +390,7 @@ export class PodStack extends TerraformStack {
           "force-terminate-connection",
         healthCheck: {
           path:
-            endpointOptions.target.protocol === "HTTP"
+            endpointOptions.target.protocol.startsWith("HTTP")
               ? endpointOptions.target.healthCheck?.path
               : undefined,
           healthyThreshold:


### PR DESCRIPTION
There was a bug in our logic where we wouldn't set the healthcheck correctly if the target was HTTPS instead of HTTP.
