### PR TITLE
Add support for Consul-based deploys

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stack",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "license": "None",
   "private": true,
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,12 +5,19 @@ import { version } from "../package.json" assert { type: "json" };
 const CLI_PATH = import.meta.path;
 
 function generateReleaseId() {
-  return `${new Date()
-    .toISOString()
-    .replace(/\:/g, "-")
-    .replace(/\./g, "-")
-    .replace("Z", "z")}`;
+  // Store the release ID in an environment variable so that we can pass to subprocesses,
+  // reusing any previously defined one if provided.
+  process.env["RELEASE_ID"] =
+    process.env["RELEASE_ID"] ||
+    `${new Date()
+      .toISOString()
+      .replace(/\:/g, "-")
+      .replace(/\./g, "-")
+      .replace("Z", "z")}`;
+
+  return process.env["RELEASE_ID"];
 }
+const RELEASE_ID = generateReleaseId();
 
 const program = new Command();
 
@@ -43,7 +50,7 @@ program
   .option(
     "-r, --release <releaseId>",
     "Name to use for the release (defaults to a timestamp)",
-    generateReleaseId()
+    RELEASE_ID
   )
   .action(async (stacks, options) => {
     const app = new App(CLI_PATH, { ...program.opts(), ...options });
@@ -56,7 +63,7 @@ program
   .option(
     "-r, --release <releaseId>",
     "Name to use for the release (defaults to a timestamp)",
-    generateReleaseId()
+    RELEASE_ID
   )
   .action(async (options) => {
     const app = new App(CLI_PATH, { ...program.opts(), ...options });
@@ -74,7 +81,7 @@ program
   .option(
     "-r, --release <releaseId>",
     "Name to use for the release (defaults to a timestamp)",
-    generateReleaseId()
+    RELEASE_ID
   )
   .option(
     "--skip-apply",
@@ -98,7 +105,7 @@ program
   .option(
     "-r, --release <releaseId>",
     "Name to use for the release (defaults to a timestamp)",
-    generateReleaseId()
+    RELEASE_ID
   )
   .action(async (stacks, options) => {
     const app = new App(CLI_PATH, { ...program.opts(), ...options });
@@ -124,7 +131,7 @@ program
   .option(
     "-r, --release <releaseId>",
     "Name to use for the release (defaults to a timestamp)",
-    generateReleaseId()
+    RELEASE_ID
   )
   .action(async (options) => {
     const app = new App(CLI_PATH, { ...program.opts(), ...options });


### PR DESCRIPTION
We want to speed up deploys and use the Consul service registry as a means to check health, since it updates faster than ASG+ALBs.

This also fixes a bug where green text would continue to be emitted after the plan/apply phase was completed.

To get this to work, we also add:
- a `deploy.orchestrator` option to switch from the default (ASG-based) to Consul
- a `deploy.healthCheckService` option to specify the name of the Consul service to check
- logic to check the status of a Consul-based service
- a pre-container-shutdown hook that allows us to gracefully deregister the Consul node before shutdown
- logic to create + delete ASGs outside of Terraform using the AWS API directly (this is much faster than waiting on Terraform which waits until the operation has fully completed, whereas we just want to kick it off and move on)
- better handling of the `RELEASE_ID` to pass it along via environment variable if it has been set, ensuring consistently across spawned subprocesses
- migration-specific code to support projects migrating from ASG-based to Consul-based deploys
