### PR TITLE
Fix setting of RELEASE_ID environment variable when specified via CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stack",
-  "version": "0.0.60",
+  "version": "0.0.61",
   "license": "None",
   "private": true,
   "type": "module",

--- a/src/app.ts
+++ b/src/app.ts
@@ -36,6 +36,10 @@ export class App {
     private readonly options: Record<string, string | boolean>
   ) {
     this.options = JSON.parse(JSON.stringify(options));
+    // Ensure subprocesses have the same release ID
+    if (this.options.release) {
+      process.env["RELEASE_ID"] = this.options.release as string;
+    }
     this.config = parseConfig(this.options.config as string);
     this.createCdktfJson();
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,17 +7,16 @@ const CLI_PATH = import.meta.path;
 function generateReleaseId() {
   // Store the release ID in an environment variable so that we can pass to subprocesses,
   // reusing any previously defined one if provided.
-  process.env["RELEASE_ID"] =
+  return (
     process.env["RELEASE_ID"] ||
     `${new Date()
       .toISOString()
       .replace(/\:/g, "-")
       .replace(/\./g, "-")
-      .replace("Z", "z")}`;
-
-  return process.env["RELEASE_ID"];
+      .replace("Z", "z")}`
+  );
 }
-const RELEASE_ID = generateReleaseId();
+const DEFAULT_RELEASE_ID = generateReleaseId();
 
 const program = new Command();
 
@@ -50,7 +49,7 @@ program
   .option(
     "-r, --release <releaseId>",
     "Name to use for the release (defaults to a timestamp)",
-    RELEASE_ID
+    DEFAULT_RELEASE_ID
   )
   .action(async (stacks, options) => {
     const app = new App(CLI_PATH, { ...program.opts(), ...options });
@@ -63,7 +62,7 @@ program
   .option(
     "-r, --release <releaseId>",
     "Name to use for the release (defaults to a timestamp)",
-    RELEASE_ID
+    DEFAULT_RELEASE_ID
   )
   .action(async (options) => {
     const app = new App(CLI_PATH, { ...program.opts(), ...options });
@@ -81,7 +80,7 @@ program
   .option(
     "-r, --release <releaseId>",
     "Name to use for the release (defaults to a timestamp)",
-    RELEASE_ID
+    DEFAULT_RELEASE_ID
   )
   .option(
     "--skip-apply",
@@ -105,7 +104,7 @@ program
   .option(
     "-r, --release <releaseId>",
     "Name to use for the release (defaults to a timestamp)",
-    RELEASE_ID
+    DEFAULT_RELEASE_ID
   )
   .action(async (stacks, options) => {
     const app = new App(CLI_PATH, { ...program.opts(), ...options });
@@ -131,7 +130,7 @@ program
   .option(
     "-r, --release <releaseId>",
     "Name to use for the release (defaults to a timestamp)",
-    RELEASE_ID
+    DEFAULT_RELEASE_ID
   )
   .action(async (options) => {
     const app = new App(CLI_PATH, { ...program.opts(), ...options });


### PR DESCRIPTION
We were not properly handling this in the case where the `--release` flag was provided.
