### PR TITLE
Improve error handling for instance refresh/consul check phase

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stack",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "license": "None",
   "private": true,
   "type": "module",


### PR DESCRIPTION
We should early exit if either of these phases fail.
