### PR TITLE
Fix initial ASG size setting to use minHealthyInstances

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stack",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "license": "None",
   "private": true,
   "type": "module",

--- a/src/app.ts
+++ b/src/app.ts
@@ -511,7 +511,7 @@ export class App {
     const maxSize =
       currentAsg?.MaxSize ??
       (podConfig.autoscaling?.minHealthyInstances ?? 1) + 1;
-    const desiredCapacity = currentAsg?.DesiredCapacity ?? 1;
+    const desiredCapacity = currentAsg?.DesiredCapacity ?? minSize;
 
     const defaultSubnetIds = podConfig.singleton
       ? undefined


### PR DESCRIPTION
On first deploy, make sure we respect the minHealthyInstances setting so that our ASG deploys successfully.
