### PR TITLE
Don't use deleting ASG to get desired instance count

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stack",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "license": "None",
   "private": true,
   "type": "module",

--- a/src/app.ts
+++ b/src/app.ts
@@ -817,7 +817,10 @@ export class App {
         },
       ],
     });
-    const asg: AutoScalingGroup | undefined = asgsResult.AutoScalingGroups?.[0];
+    const asg = asgsResult.AutoScalingGroups?.sort(
+      (a, b) =>
+        (b.CreatedTime?.getTime() ?? 0) - (a.CreatedTime?.getTime() ?? 0)
+    )?.[0];
     return (
       asg?.DesiredCapacity ??
       this.config.pods[podName].autoscaling?.minHealthyInstances ??
@@ -1864,7 +1867,10 @@ export class App {
             },
           ],
         });
-        const asg = asgResult.AutoScalingGroups?.[0];
+        const asg = asgResult.AutoScalingGroups?.sort(
+          (a, b) =>
+            (b.CreatedTime?.getTime() ?? 0) - (a.CreatedTime?.getTime() ?? 0)
+        )[0];
         currentAsg = {
           minSize: asg?.MinSize ?? 1,
           maxSize: asg?.MaxSize ?? 2,


### PR DESCRIPTION
If we were deleting an old ASG, the filter would use its desired instance count instead of the correct number.
