### PR TITLE
Add support for specifying pod name as Docker Compose profile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stack",
-  "version": "0.0.66",
+  "version": "0.0.67",
   "license": "None",
   "private": true,
   "type": "module",

--- a/src/app.ts
+++ b/src/app.ts
@@ -622,7 +622,10 @@ export class App {
     // Get the last created ASG, since there might be multiple ASGs due to other/earlier deployments that haven't yet been cleaned up
     const oldAsgs = asgResult.AutoScalingGroups?.filter(
       (asg) =>
-        asg.Tags?.find((tag) => tag.Key === "release")?.Value !== releaseId
+        asg.Tags?.find((tag) => tag.Key === "release")?.Value !== releaseId &&
+        asg.AutoScalingGroupName?.includes(
+          "Z" // Terraform-based ASGs don't have "Z" from a timestamp in their name
+        ) /* Only delete ASGs with release ID in name (new type of ASG) */
     );
     if (oldAsgs?.length) {
       const results = await Promise.allSettled(
@@ -1435,7 +1438,7 @@ export class App {
 
     # Start up all pod containers
     echo "Starting new containers for pod ${podName} on ${instanceId} ${ip} for release ${releaseId}"
-    docker compose up --detach --quiet-pull --pull=missing
+    COMPOSE_PROFILES="${podName}" docker compose up --detach --quiet-pull --pull=missing
 
     # Delete old images + containers
     docker system prune --force

--- a/src/util.ts
+++ b/src/util.ts
@@ -44,6 +44,8 @@ if [ ! -d /home/${sshUser}/releases/${releaseId} ]; then
   echo "PROJECT=${namespace}" >> .static.env
   echo "RELEASE=${releaseId}" >> .static.env
   echo "POD_NAME=${pod}" >> .static.env
+  REGION=$(curl -s -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)
+  echo "REGION=\$REGION" >> .static.env
   INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" http://169.254.169.254/latest/meta-data/instance-id)
   echo "INSTANCE_ID=\$INSTANCE_ID" >> .static.env
   echo "\$INSTANCE_ID" | sudo tee /etc/instance-id > /dev/null
@@ -113,7 +115,7 @@ if [ ! -d /home/${sshUser}/releases/${releaseId} ]; then
     # Avoid weird errors on first boot; see https://github.com/moby/moby/issues/22074#issuecomment-856551466
     sudo systemctl restart docker
 
-    docker compose up --detach --quiet-pull --pull=missing
+    COMPOSE_PROFILES="${pod}" docker compose up --detach --quiet-pull --pull=missing
     echo "Finished starting Docker containers $(cat /proc/uptime | awk '{ print $1 }') seconds after boot"
     echo "$new_release_dir" > /home/${sshUser}/releases/current
   fi


### PR DESCRIPTION
This allows us to provide `deploy-docker-compose.yml` configuration files that can conditionally start some containers based on the pod.

While here, also add a feature to not tear down old Terraform-style ASGs since we want to be able to smoothly migrate from instance refresh-based deploys to Consul-based deploys.

Finally, include `REGION` in the `.env` file so it can be referenced in Docker Compose configurations.
