### PR TITLE
Also specify COMPOSE_PROFILES for build and pull steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stack",
-  "version": "0.0.67",
+  "version": "0.0.68",
   "license": "None",
   "private": true,
   "type": "module",

--- a/src/util.ts
+++ b/src/util.ts
@@ -109,8 +109,8 @@ if [ ! -d /home/${sshUser}/releases/${releaseId} ]; then
     if [ -n "$STACK_DOCKER_IMAGE" ]; then
       docker pull $STACK_DOCKER_IMAGE
     fi
-    docker compose build
-    docker compose pull --quiet --ignore-buildable --policy=missing # Specify "missing" so we don't re-pull images we already have cached
+    COMPOSE_PROFILES="${pod}" docker compose build
+    COMPOSE_PROFILES="${pod}" docker compose pull --quiet --ignore-buildable --policy=missing # Specify "missing" so we don't re-pull images we already have cached
   else
     # Avoid weird errors on first boot; see https://github.com/moby/moby/issues/22074#issuecomment-856551466
     sudo systemctl restart docker


### PR DESCRIPTION
No need to build/pull containers whose profile doesn't apply to the current pod.
