### PR TITLE
Delete new ASG on deploy failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stack",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "license": "None",
   "private": true,
   "type": "module",


### PR DESCRIPTION
This ensures we don't keep leaking the creation of new ASGs with each failed deploy.
