### PR TITLE
Switch action-gh-release to v2.2.2 since v2.3.0 is broken

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           touch ./build/stack
           chmod +x ./build/stack
           echo "${{ github.ref_name }}" | cat bin/exec-stack-via-docker.sh - > ./build/stack
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v2.2.2
         with:
           generate_release_notes: true
           make_latest: true


### PR DESCRIPTION
See https://github.com/softprops/action-gh-release/issues/627

Revert for now.
