### PR TITLE
Allow specifying custom LB name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stack",
-  "version": "0.0.75",
+  "version": "0.0.76",
   "license": "None",
   "private": true,
   "type": "module",

--- a/src/config.ts
+++ b/src/config.ts
@@ -132,6 +132,7 @@ export const DeployConfigSchema = Type.Object({
         Type.Record(
           Type.String(),
           Type.Object({
+            awsName: Type.Optional(Type.String()),
             type: Type.Union([
               Type.Literal("application"),
               Type.Literal("network"),

--- a/src/stacks/PodStack.ts
+++ b/src/stacks/PodStack.ts
@@ -88,7 +88,9 @@ export class PodStack extends TerraformStack {
           `Load balancer ${lbName} for pod ${fullPodName} has an idle-timeout specified, but is not an application load balancer`
         );
       }
-      const uniqueLbName = `${options.project}-pod-${options.shortName}-${lbName}`;
+      const uniqueLbName =
+        lbOptions.awsName ||
+        `${options.project}-pod-${options.shortName}-${lbName}`;
 
       const lbSg = new SmartSecurityGroup(this, `lb-ssg-${uniqueLbName}`, {
         project: options.project,


### PR DESCRIPTION
Sometimes the default name is longer than the max 32 characters allowed. Provide a way to override for these situations.
