### PR TITLE
Update build process to remove use of Depot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: write # Upload artifacts and cut releases
-  id-token: write # OIDC for Depot
+  id-token: write # OIDC
 
 jobs:
   publish-docker-images:
@@ -19,37 +19,21 @@ jobs:
         with:
           username: ${{ vars.FARCASTERXYZ_DOCKERHUB_USER }}
           password: ${{ secrets.FARCASTERXYZ_DOCKERHUB_WRITE_PASSWORD }}
-      - uses: depot/setup-action@v1
+
       - run: env STACK_VERSION=${{ github.sha }} ./bin/publish-image.sh
         shell: bash
-        env:
-          DEPOT_PROJECT_ID: ${{ secrets.DEPOT_PROJECT_ID }}
 
-  publish-executable:
-    needs: [publish-docker-images]
-    # Only run if a tag was pushed
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      # Should already be built, we just want to publish the specific version tag
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ vars.FARCASTERXYZ_DOCKERHUB_USER }}
-          password: ${{ secrets.FARCASTERXYZ_DOCKERHUB_WRITE_PASSWORD }}
-      - uses: depot/setup-action@v1
-      - run: env STACK_VERSION=${{ github.ref_name }} ./bin/publish-image.sh
-        shell: bash
-        env:
-          DEPOT_PROJECT_ID: ${{ secrets.DEPOT_PROJECT_ID }}
-      - name: Append version tag to executable
+      - if: startsWith(github.ref, 'refs/tags/')
+        name: Append version tag to executable
         shell: bash
         run: |
           mkdir -p ./build
           touch ./build/stack
           chmod +x ./build/stack
           echo "${{ github.ref_name }}" | cat bin/exec-stack-via-docker.sh - > ./build/stack
-      - uses: softprops/action-gh-release@v2.2.2
+
+      - if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2.2.2
         with:
           generate_release_notes: true
           make_latest: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # `stack`
 
 Tool for deploying services on AWS EC2 instances.
+**Not recommended for external use.**
+
+## Publishing a new Stack version
+
+1. Updated the version in [`package.json`](package.json). Commit your changes.
+2. Tag the commit you wish to release with a name of the form `vX.Y.Z`.
+3. Push that tag to this repo to have a Docker image published to `farcasterxyz/stack` on Docker Hub.
 
 ## Installation
 
@@ -9,7 +16,7 @@ Stack is distributed as a Docker image.
 ### Requirements
 
 - Docker
-- **Architecture**: x86_64 (a.k.a. Intel) or arm64 (a.k.a. Apple Silicon)
+- **Architecture**: arm64 (a.k.a. Apple Silicon)
 
 To avoid having to install Terraform + the Terraform CDK, a Docker image is provided along with a helper script you can install to make running Stack easier.
 

--- a/bin/publish-image.sh
+++ b/bin/publish-image.sh
@@ -12,8 +12,8 @@ STACK_VERSION=${STACK_VERSION:-$(git rev-parse HEAD)}
 
 echo "Publishing Stack $STACK_VERSION"
 
-depot build -f Dockerfile \
-  --platform "linux/amd64,linux/arm64" \
+docker build -f Dockerfile \
+  --platform "linux/arm64" \
   --push \
   -t farcasterxyz/stack:${STACK_VERSION} \
   -t farcasterxyz/stack:latest \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stack",
-  "version": "0.0.91",
+  "version": "0.0.92",
   "license": "None",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Use vanilla Docker CLI instead. To make this work without changing too much, limit the builds to ARM64 only.

We update the version in `package.json` since we want to test the build + publish process still works.
