### PR TITLE
feat: support pre-release workflows with the stack deploy github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,5 +34,8 @@ jobs:
       - uses: softprops/action-gh-release@v2.2.2
         with:
           generate_release_notes: true
-          make_latest: true
+          # Tags with a hyphen (e.g. v1.2.3-pre1) are treated as pre-releases
+          # so they don't become the "latest" pointer that install.sh follows.
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ contains(github.ref_name, '-') && 'false' || 'true' }}
           files: build/stack

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,10 @@
 # You can run it anywhere by executing:
 #
 # /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/merkle-team/stack/refs/heads/main/install.sh)"
+#
+# To install a specific version (including pre-releases), set STACK_VERSION:
+#
+# STACK_VERSION=v1.2.3-pre1 /bin/bash -c "$(curl -fsSL ...)"
 
 set -euo pipefail
 
@@ -54,10 +58,16 @@ if ! chmod +x $location; then
   sudo chmod +x $location
 fi
 
-download_url=$(curl -s https://api.github.com/repos/merkle-team/stack/releases/latest | jq -r ".assets[] | select(.name  == \"stack\") | .browser_download_url")
-if [ -z "$download_url" ]; then
-  echo "Could not find download URL for latest version of Stack"
-  exit 1
+if [ -n "${STACK_VERSION:-}" ]; then
+  # Pin to a specific tag (works for pre-releases too, which the /releases/latest endpoint excludes).
+  download_url="https://github.com/merkle-team/stack/releases/download/${STACK_VERSION}/stack"
+  echo "Installing Stack ${STACK_VERSION}"
+else
+  download_url=$(curl -s https://api.github.com/repos/merkle-team/stack/releases/latest | jq -r ".assets[] | select(.name  == \"stack\") | .browser_download_url")
+  if [ -z "$download_url" ]; then
+    echo "Could not find download URL for latest version of Stack"
+    exit 1
+  fi
 fi
 
 $sudo curl -fsSL "$download_url" --output $location


### PR DESCRIPTION
We can now utilize specific stack releases via an env var, `STACK_VERSION`. If not set it false back to the `latest` production at least, which is what is hardcoded right now.
